### PR TITLE
use mpi_f08 module, etc

### DIFF
--- a/mpi/basic.f90
+++ b/mpi/basic.f90
@@ -1,21 +1,16 @@
 program basic
 
-use mpi, only : mpi_init
+use mpi_f08, only : MPI_Init, MPI_Finalize
 
 implicit none (type, external)
 
-external :: mpi_finalize
-integer :: ierr
-
 print *, "going to init MPI"
 
-call MPI_INIT(ierr)
-if(ierr /= 0) error stop "could not init MPI"
+call MPI_Init()
 
 print *, "MPI Init OK"
 
-call MPI_FINALIZE(ierr)
-if(ierr /= 0) error stop "could not close MPI"
+call MPI_Finalize()
 
 print *, "MPI closed"
 

--- a/mpi/helloworld.f90
+++ b/mpi/helloworld.f90
@@ -2,43 +2,47 @@ program hw_mpi
 !!    Each process prints out a "Hello, world!" message with a process ID
 !!  Original Author:  John Burkardt
 !!  Modified: Michael Hirsch, Ph.D.
+!!  Modified: Jeff Hammond
 
-use mpi, only : mpi_init, mpi_comm_size, mpi_comm_world, mpi_wtime
+use mpi_f08, only : MPI_Init, MPI_Finalize, MPI_Wtime, &
+                    MPI_Comm_size, MPI_Comm_rank, MPI_COMM_WORLD, &
+                    MPI_Barrier
+
 use, intrinsic:: iso_fortran_env, only: dp=>real64, compiler_version
 
 implicit none (type, external)
 
-integer :: i, Nproc, ierr
+integer :: me, np, i
 real(dp) :: wtime
 
-external :: mpi_comm_rank, mpi_finalize
-
 !>  Initialize MPI.
-call MPI_Init(ierr)
-if (ierr /= 0) error stop 'mpi init error'
+call MPI_Init()
 
 !>  Get the number of processes.
-call MPI_Comm_size(MPI_COMM_WORLD, Nproc, ierr)
+call MPI_Comm_size(MPI_COMM_WORLD, np)
 
 !>  Get the individual process ID.
-call MPI_Comm_rank(MPI_COMM_WORLD, i, ierr)
+call MPI_Comm_rank(MPI_COMM_WORLD, me)
 
 !>  Print a message.
-if (i == 0) then
+if (me == 0) then
   print *,compiler_version()
   wtime = MPI_Wtime()
-  print *, 'number of processes: ', Nproc
+  print *, 'number of processes: ', np
 end if
 
-print *, 'Process ', i
+!> Print process ranks with total ordering
+do i=0,np
+    call MPI_Barrier(MPI_COMM_WORLD)
+    if (me.eq.i) print *, 'Process ', me
+end do
 
-if ( i == 0 ) then
+if ( me == 0 ) then
   wtime = MPI_Wtime() - wtime
   print *, 'Elapsed wall clock time = ', wtime, ' seconds.'
 end if
 
 !>  Shut down MPI.
-call MPI_Finalize(ierr)
-if (ierr /= 0) error stop 'mpi finalize error'
+call MPI_Finalize()
 
 end program

--- a/mpi/mpivers.f90
+++ b/mpi/mpivers.f90
@@ -2,31 +2,28 @@ program mpi_vers
 ! https://github.com/open-mpi/ompi/blob/master/examples/hello_usempif08.f90
 
 use, intrinsic :: iso_fortran_env, only : compiler_version
-use mpi, only : MPI_MAX_LIBRARY_VERSION_STRING, mpi_get_library_version, mpi_init, &
-  MPI_COMM_SIZE, mpi_comm_world
+
+use mpi_f08, only : MPI_Init, MPI_Finalize, MPI_Comm_rank, MPI_Comm_size, MPI_COMM_WORLD, &
+                    MPI_Barrier, MPI_Get_library_version, MPI_MAX_LIBRARY_VERSION_STRING
 
 implicit none (type, external)
 
-external :: mpi_finalize, mpi_comm_rank
-
-integer :: ierr, id, Nimg, vlen
+integer :: id, Nimg, vlen
 character(MPI_MAX_LIBRARY_VERSION_STRING) :: version  ! allocatable not ok
 
+call MPI_Init()
 
-print *,compiler_version()
+call MPI_Comm_rank(MPI_COMM_WORLD, id)
 
-call MPI_INIT(ierr)
-if(ierr /= 0) error stop "could not init MPI"
+call MPI_Comm_size(MPI_COMM_WORLD, Nimg)
+call MPI_Get_library_version(version, vlen)
 
-call MPI_COMM_RANK(MPI_COMM_WORLD, id, ierr)
-if (ierr /= 0) error stop "could not get MPI rank"
-
-call MPI_COMM_SIZE(MPI_COMM_WORLD, Nimg, ierr)
-call MPI_GET_LIBRARY_VERSION(version, vlen, ierr)
-
+if (id .eq. 0) then
+    print *,compiler_version()
+end if
+call MPI_Barrier(MPI_COMM_WORLD)
 print '(A,I3,A,I3,A)', 'MPI: Image ', id, ' / ', Nimg, ':', trim(version)
 
-call MPI_FINALIZE(ierr)
-if(ierr /= 0) error stop "could not close MPI"
+call MPI_Finalize()
 
 end program


### PR DESCRIPTION
1) use mpi_f08 is the right way to use MPI with Fortran 2018
   remove external declarations in favor of use+only
2) implement total ordering on process rank print
3) remove error checking because no errors are handled in a way that justifies it.
   MPI errors are fatal by default so "if (error) stop" is pointless.
4) me is a more obvious rank variable than "i".

Signed-off-by: Jeff Hammond <jeff.science@gmail.com>